### PR TITLE
Add date selection logic

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -116,10 +116,94 @@ app.post("/add-task", async (req, res) => {
   }
 });
 
+// Report routes
 
+// Get date ranges
+app.get("/date-ranges", async (req, res) => {
+  const collection = client.db("hack4good").collection("date-ranges");
 
+  try {
+    const dateRanges = await collection
+      .find()
+      .sort({ accessed_at: -1 })
+      .toArray();
 
+    const dateRangesWithId = dateRanges.map((range) => ({
+      id: range._id.toString(),
+      ...range,
+    }));
 
+    return res.status(200).json(dateRangesWithId);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Add date range
+app.post("/date-ranges", async (req, res) => {
+  const collection = client.db("hack4good").collection("date-ranges");
+  const { from, to, accessed_at } = req.body;
+
+  if (!from || !to || !accessed_at) {
+    return res.status(400).json({ error: "Missing required fields: from, to, or accessed_at" });
+  }
+
+  try {
+    const result = await collection.insertOne({ from, to, accessed_at });
+    return res
+      .status(200)
+      .json({ message: `Date range ${result.insertedId} created.`, id: result.insertedId });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Check if a date range already exists
+app.post("/date-ranges/check", async (req, res) => {
+  const collection = client.db("hack4good").collection("date-ranges");
+  const { from, to } = req.body;
+
+  try {
+    const existingRange = await collection.findOne({
+      from: from,
+      to: to
+    });
+
+    if (existingRange) {
+      return res.json({ exists: true, id: existingRange._id });
+    } else {
+      return res.json({ exists: false });
+    }
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Update a date range's accessed_at
+app.put("/date-ranges/:id", async (req, res) => {
+  const collection = client.db("hack4good").collection("date-ranges");
+  const { id } = req.params;
+  const { accessed_at } = req.body;
+
+  try {
+    if (!ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "Invalid ObjectId" });
+    }
+
+    const updatedRange = await collection.updateOne(
+      { _id: new ObjectId(id) },
+      { $set: { accessed_at } }
+    );
+
+    if (updatedRange.modifiedCount > 0) {
+      return res.status(200).json({ message: "Date range updated successfully" });
+    } else {
+      return res.status(404).json({ message: "Date range not found" });
+    }
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
 
 
 const port = process.env.PORT || 8080;

--- a/frontend/src/app/admin/reports/DatePickerForm.tsx
+++ b/frontend/src/app/admin/reports/DatePickerForm.tsx
@@ -2,8 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { format } from "date-fns"
-import { CalendarIcon } from "lucide-react"
 import { useRouter } from "next/navigation"
+import { CalendarIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
@@ -38,26 +38,67 @@ const FormSchema = z.object({
 })
 
 export function DatePickerForm() {
-  const router = useRouter()
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
   })
 
-  // function onSubmit(data: z.infer<typeof FormSchema>) {
-  //   toast({
-  //     title: "You submitted the following values:",
-  //     description: (
-  //       <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-  //         <code className="text-white">{JSON.stringify(data, null, 2)}</code>
-  //       </pre>
-  //     ),
-  //   })
-  // }
+  const router = useRouter()  
+
   function onSubmit(data: z.infer<typeof FormSchema>) {
-    const { from, to } = data.dateRange
+    const { from, to } = data.dateRange;
 
-    router.push(`/admin/reports/report?from=${from.toISOString()}&to=${to.toISOString()}`)
+    const payload = {
+      from: from.toISOString(),
+      to: to.toISOString(),
+      accessed_at: new Date().toISOString(),
+    };
 
+    fetch("http://localhost:8080/date-ranges/check", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to check if date range exists");
+        }
+        return response.json();
+      })
+      .then((result) => {
+        if (result.exists) {
+          return fetch(`http://localhost:8080/date-ranges/${result.id}`, {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              accessed_at: new Date().toISOString(),
+            }),
+          });
+        } else {
+          return fetch("http://localhost:8080/date-ranges", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          });
+        }
+      })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to update or add date range");
+        }
+        return response.json();
+      })
+      .then(() => {
+        router.push(`/admin/reports/report?from=${from.toISOString()}&to=${to.toISOString()}`);
+      })
+      .catch((error) => {
+        console.error(error.message);
+      });
   }
 
   return (

--- a/frontend/src/app/admin/reports/Table.tsx
+++ b/frontend/src/app/admin/reports/Table.tsx
@@ -1,78 +1,73 @@
 "use client"
 
 import {
-    Table,
-    TableBody,
-    TableCaption,
-    TableCell,
-    TableFooter,
-    TableHead,
-    TableHeader,
-    TableRow,
-  } from "@/components/ui/table"
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 
-  import { format } from "date-fns"
-  import { useRouter } from "next/navigation"
-  import { ScrollArea } from "@/components/ui/scroll-area"
-  import { Separator } from "@/components/ui/separator"
-  
-  const dateRanges = [
-    {
-      dateRange: { from: new Date("2025-01-01"), to: new Date("2025-01-07") },
-    },
-    {
-      dateRange: { from: new Date("2025-01-08"), to: new Date("2025-01-14") },
-    },
-    {
-      dateRange: { from: new Date("2025-01-15"), to: new Date("2025-01-21") },
-    },
-    {
-      dateRange: { from: new Date("2025-01-22"), to: new Date("2025-01-28") },
-    },
-    {
-      dateRange: { from: new Date("2025-01-29"), to: new Date("2025-02-04") },
-    },
-    {
-      dateRange: { from: new Date("2025-02-05"), to: new Date("2025-02-11") },
-    },
-    {
-      dateRange: { from: new Date("2025-02-12"), to: new Date("2025-02-18") },
-    },
-  ]
-  
-  export function DatesTable() {
-    const router = useRouter()
+import { format } from "date-fns"
+import { useRouter } from "next/navigation"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
 
-    const handleRowClick = (from: Date, to: Date) => {
-      const fromString = from.toISOString()
-      const toString = to.toISOString()
+type DatesTableProps = {
+  dateRanges: { id: string; from: Date; to: Date; accessed_at?: Date }[]
+}
+
+export function DatesTable({ dateRanges }: DatesTableProps) {
+  const router = useRouter()
+
+  const handleRowClick = (id: string, from: Date, to: Date) => {
+    const fromString = new Date(from).toISOString()
+    const toString = new Date(to).toISOString()
+
+    try {
+      const response = fetch(`http://localhost:8080/date-ranges/${id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          accessed_at: new Date().toISOString(),
+        }),
+      })
+
       router.push(`/admin/reports/report?from=${fromString}&to=${toString}`)
+    } catch (error) {
+      console.error("Error updating date range:", error)
     }
-    return (
-      <div className="w-2/3 flex flex-col">
-        <label className="block text-sm font-medium text-black mb-2">
-          Select a previously generated report
-        </label>
-        <ScrollArea className="h-72 rounded-md border">
-          <div className="p-4">
-            <h4 className="mb-4 text-sm font-medium leading-none">Date Range</h4>
-            {dateRanges.map((item, index) => (
-              <div key={index}>
-                <div
-                  className="text-sm cursor-pointer hover:text-blue-600"
-                  onClick={() =>
-                    handleRowClick(item.dateRange.from, item.dateRange.to)
-                  }
-                >
-                  {format(item.dateRange.from, "LLL dd, y")} -{" "}
-                  {format(item.dateRange.to, "LLL dd, y")}
-                </div>
-                {index < dateRanges.length - 1 && <Separator className="my-2" />}
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-      </div>
-    )
   }
-  
+
+  return (
+    <div className="w-2/3 flex flex-col">
+      <label className="block text-sm font-medium text-black mb-2">
+        Select a previously generated report
+      </label>
+      <ScrollArea className="max-h-72 h-auto overflow-y-auto rounded-md border">
+        <div className="p-4">
+          <h4 className="mb-4 text-sm font-medium leading-none">Date Range</h4>
+          {dateRanges.map((item, index) => (
+            <div key={index}>
+              <div
+                className="text-sm cursor-pointer hover:text-blue-600"
+                onClick={() =>
+                  handleRowClick(item.id, item.from, item.to)
+                }
+              >
+                {format(item.from, "LLL dd, y")} -{" "}
+                {format(item.to, "LLL dd, y")}
+              </div>
+              {index < dateRanges.length - 1 && <Separator className="my-2" />}
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/frontend/src/app/admin/reports/page.tsx
+++ b/frontend/src/app/admin/reports/page.tsx
@@ -1,3 +1,6 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { AppSidebar } from "@/components/app-sidebar"
 import {
   Breadcrumb,
@@ -18,6 +21,24 @@ import { DatePickerForm } from "./DatePickerForm"
 import { DatesTable } from "./Table"
 
 export default function Page() {
+  const [dateRanges, setDateRanges] = useState([])
+
+  useEffect(() => {
+    const fetchDateRanges = async () => {
+      try {
+        const response = await fetch("http://localhost:8080/date-ranges")
+        const data = await response.json()
+        setDateRanges(data)
+      } catch (error) {
+        console.error("Failed to fetch date ranges:", error)
+      }
+    }
+
+    fetchDateRanges()
+  }, [])
+
+  const isDateRangesEmpty = dateRanges.length === 0
+
   return (
     <SidebarProvider>
       <AppSidebar />
@@ -29,9 +50,7 @@ export default function Page() {
             <Breadcrumb>
               <BreadcrumbList>
                 <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href="/admin">
-                    Admin
-                  </BreadcrumbLink>
+                  <BreadcrumbLink href="/admin">Admin</BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator className="hidden md:block" />
                 <BreadcrumbItem>
@@ -41,16 +60,17 @@ export default function Page() {
             </Breadcrumb>
           </div>
         </header>
-        <div className="flex flex-1 justify-between items-center p-4 pt-0">
-          <div className="w-1/2 justify-center flex">
-            <DatesTable />
-          </div>
-          <div className="flex w-1/2">
+        <div className={`flex flex-1 items-center p-4 pt-0 ${isDateRangesEmpty ? "justify-center" : "justify-between"}`}>
+          {!isDateRangesEmpty && (
+            <div className="w-1/2 flex justify-center">
+              <DatesTable dateRanges={dateRanges} />
+            </div>
+          )}
+          <div className={`${isDateRangesEmpty ? "w-full flex justify-center" : "w-1/2 flex"}`}>
             <DatePickerForm />
           </div>
         </div>
       </SidebarInset>
     </SidebarProvider>
-    
   )
 }


### PR DESCRIPTION
Closes #13

- Date ranges are ordered in descending order of when they were accessed
- Accessing a date range again updates the accessed_at timing (if generating a new report with date ranges used before, it updates this timing as well, no duplicates are created)